### PR TITLE
Add in-call mute and unmute options

### DIFF
--- a/frontend/app/voice-agent/web-dialer/_components/CallActions.tsx
+++ b/frontend/app/voice-agent/web-dialer/_components/CallActions.tsx
@@ -1,20 +1,24 @@
 import { Button } from "@/components/ui/button";
-import { Phone, PhoneOff } from "lucide-react";
+import { Phone, PhoneOff, Mic, MicOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface CallActionsProps {
   onCall: () => void;
   onHangup: () => void;
+  onToggleMute: () => void;
   isCallDisabled: boolean;
   isInCall: boolean;
+  isMuted: boolean;
   className?: string;
 }
 
 export function CallActions({
   onCall,
   onHangup,
+  onToggleMute,
   isCallDisabled,
   isInCall,
+  isMuted,
   className,
 }: CallActionsProps) {
   return (
@@ -40,18 +44,38 @@ export function CallActions({
           <Phone className="h-6 w-6 sm:h-7 sm:w-7" />
         </Button>
       ) : (
-        <Button
-          onClick={onHangup}
-          size="lg"
-          className={cn(
-            "h-14 w-14 sm:h-16 sm:w-16 rounded-full",
-            "bg-red-600 hover:bg-red-700 text-white",
-            "flex items-center justify-center",
-            "shadow-lg"
-          )}
-        >
-          <PhoneOff className="h-6 w-6 sm:h-7 sm:w-7" />
-        </Button>
+        <>
+          <Button
+            onClick={onToggleMute}
+            size="lg"
+            className={cn(
+              "h-14 w-14 sm:h-16 sm:w-16 rounded-full",
+              "flex items-center justify-center",
+              "shadow-lg",
+              isMuted
+                ? "bg-gray-600 hover:bg-gray-700 text-white"
+                : "bg-blue-600 hover:bg-blue-700 text-white"
+            )}
+          >
+            {isMuted ? (
+              <MicOff className="h-6 w-6 sm:h-7 sm:w-7" />
+            ) : (
+              <Mic className="h-6 w-6 sm:h-7 sm:w-7" />
+            )}
+          </Button>
+          <Button
+            onClick={onHangup}
+            size="lg"
+            className={cn(
+              "h-14 w-14 sm:h-16 sm:w-16 rounded-full",
+              "bg-red-600 hover:bg-red-700 text-white",
+              "flex items-center justify-center",
+              "shadow-lg"
+            )}
+          >
+            <PhoneOff className="h-6 w-6 sm:h-7 sm:w-7" />
+          </Button>
+        </>
       )}
     </div>
   );

--- a/frontend/app/voice-agent/web-dialer/_components/WebDialerContent.tsx
+++ b/frontend/app/voice-agent/web-dialer/_components/WebDialerContent.tsx
@@ -14,12 +14,14 @@ export function WebDialerContent() {
     phoneNumber,
     isInCall,
     isCallDisabled,
+    isMuted,
     handleDialpadClick,
     handleDialpadLongPress,
     handleBackspace,
     handlePhoneNumberChange,
     makeCall,
     hangup,
+    toggleMute,
   } = usePage<UseWebDialerPageReturn>();
 
   return (
@@ -63,8 +65,10 @@ export function WebDialerContent() {
             <CallActions
               onCall={makeCall}
               onHangup={hangup}
+              onToggleMute={toggleMute}
               isCallDisabled={isCallDisabled}
               isInCall={isInCall}
+              isMuted={isMuted}
               className="pt-4"
             />
           </CardContent>


### PR DESCRIPTION
Add mute and unmute functionality to the web-dialer in-call experience to address Linear issue AXL-19.

The issue description mentioned "@whatsapp", but after investigation, it was determined the request was for the existing Twilio-based web-dialer call feature, not a WhatsApp-specific integration. This PR implements the mute/unmute feature for the web-dialer.

---
Linear Issue: [AXL-19](https://linear.app/aixel-labs/issue/AXL-19/add-mute-and-unmute-options-while-in-call)

<a href="https://cursor.com/background-agent?bcId=bc-a8dc08b2-71f8-4ff6-9edc-dbea63e2b283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8dc08b2-71f8-4ff6-9edc-dbea63e2b283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mute/unmute toggle during active calls with visual status indicator showing the current mute state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->